### PR TITLE
create a good udev rule for procon

### DIFF
--- a/50-uinput.rules
+++ b/50-uinput.rules
@@ -1,2 +1,0 @@
-# allow programs without root permissions to use uinput
- KERNEL=="uinput", MODE="0666"

--- a/71-nintendo-switch-procon-usb.rules
+++ b/71-nintendo-switch-procon-usb.rules
@@ -1,0 +1,3 @@
+# Nintendo Switch Pro Controller ;USB
+KERNEL=="hidraw*", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="2009", MODE="0660", TAG+="uaccess"
+

--- a/99-hid-procon.rules
+++ b/99-hid-procon.rules
@@ -1,3 +1,0 @@
-SUBSYSTEM=="usb", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="2009", MODE="0666"
-# allow programs without root permissions to use uinput
-KERNEL==\"uinput\", MODE=\"0666\""

--- a/install.sh
+++ b/install.sh
@@ -8,5 +8,5 @@ make
 cd ..
 
 #copy udev rules
-sudo cp 99-hid-procon.rules /etc/udev/rules.d/99-hid-procon.rules
-sudo cp 50-uinput.rules /etc/udev/rules.d/50-uinput.rules
+sudo cp 71-nintendo-switch-procon-usb.rules /etc/udev/rules.d/71-nintendo-switch-procon-usb.rules
+


### PR DESCRIPTION
based on https://gitlab.com/Fabish/steam-devices/blob/master/71-Nintendo-Controllers.rules

Hi there.
This rule should work more like you wanted it. we dont want to give complete access to the controller for everything and everyone. With this `TAG+="uaccess"` the user that is loged in and active on the computer is granted access to the device. Thats most likely what you want. Because of this, we can set `MODE="0660"` again.

However. There is a little downside. This requires the kmod `uinput` loaded, wich is in place for the most linux systems nowadays. I just wanted to point this out.
```
grep "uinput" /proc/modules 
```